### PR TITLE
CASMINST-7278 New license-checker with public image

### DIFF
--- a/.github/workflows/license-check.yaml
+++ b/.github/workflows/license-check.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2024 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -29,10 +29,8 @@ on:
 jobs:
   license-check:
     runs-on: ubuntu-latest
-    container:
-      image: artifactory.algol60.net/csm-docker/stable/license-checker:latest
-      credentials:
-          username: ${{ secrets.ARTIFACTORY_ALGOL60_READONLY_USERNAME }}
-          password: ${{ secrets.ARTIFACTORY_ALGOL60_READONLY_TOKEN }}
+    permissions:
+      contents: read
+
     steps:
-      - uses: Cray-HPE/license-checker@main
+      - uses: Cray-HPE/license-checker@v2


### PR DESCRIPTION
## Summary and Scope

Use new version of license-checker, which uses image from public registry.
